### PR TITLE
fix(git): repo names with dots in their names

### DIFF
--- a/commit/git.go
+++ b/commit/git.go
@@ -80,7 +80,7 @@ func (g Git) Commits(ctx context.Context, tag1, tag2 string) ([]string, error) {
 	return logs, nil
 }
 
-var infoRe = regexp.MustCompile(`github\.com[:/](?P<user>[^/]+)/(?P<repo>[^\n.]+)(\.git)?`)
+var infoRe = regexp.MustCompile(`github\.com[:/](?P<user>[^/]+)/(?P<repo>.+?)(?:.git)?\n?$`)
 
 // RepoInfo returns some information about the repository.
 func (g Git) RepoInfo(ctx context.Context) (user, repo string, err error) {
@@ -97,7 +97,7 @@ func (g Git) RepoInfo(ctx context.Context) (user, repo string, err error) {
 	}
 
 	info := infoRe.FindStringSubmatch(string(out))
-	if len(info) != 4 {
+	if len(info) != 3 {
 		return "", "", fmt.Errorf("could not parse repository info: %s", string(out))
 	}
 	user = info[1]

--- a/commit/git_test.go
+++ b/commit/git_test.go
@@ -118,19 +118,30 @@ func testGitRepoInfo(t *testing.T) {
 
 	wantUser := "arsham666"
 	wantRepo := "gitrelease777"
-	addrs := map[string]string{
-		"git protocol":      fmt.Sprintf("git@github.com:%s/%s", wantUser, wantRepo),
-		"git protocol tail": fmt.Sprintf("git@github.com:%s/%s.git", wantUser, wantRepo),
-		"no protocol":       fmt.Sprintf("github.com/%s/%s", wantUser, wantRepo),
-		"no protocol tail":  fmt.Sprintf("github.com/%s/%s.git", wantUser, wantRepo),
-		"protocol":          fmt.Sprintf("https://github.com/%s/%s", wantUser, wantRepo),
-		"protocol tail":     fmt.Sprintf("https://github.com/%s/%s.git", wantUser, wantRepo),
+	addrs := map[string]struct {
+		addr     string
+		wantUser string
+		wantRepo string
+	}{
+		"git protocol":          {"git@github.com:%s/%s", wantUser, wantRepo},
+		"git protocol dot":      {"git@github.com:%s/%s", wantUser, wantRepo + ".nvim"},
+		"git protocol tail":     {"git@github.com:%s/%s.git", wantUser, wantRepo},
+		"git protocol tail dot": {"git@github.com:%s/%s.git", wantUser, wantRepo + ".nvim"},
+		"no protocol":           {"github.com/%s/%s", wantUser, wantRepo},
+		"no protocol dot":       {"github.com/%s/%s", wantUser, wantRepo + ".nvim"},
+		"no protocol tail":      {"github.com/%s/%s.git", wantUser, wantRepo},
+		"no protocol tail dot":  {"github.com/%s/%s.git", wantUser, wantRepo + ".nvim"},
+		"protocol":              {"https://github.com/%s/%s", wantUser, wantRepo},
+		"protocol dot":          {"https://github.com/%s/%s", wantUser, wantRepo + ".nvim"},
+		"protocol tail":         {"https://github.com/%s/%s.git", wantUser, wantRepo},
+		"protocol tail dot":     {"https://github.com/%s/%s.git", wantUser, wantRepo + ".nvim"},
 	}
 
-	for name, addr := range addrs {
+	for name, tc := range addrs {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			dir := createGitRepo(t)
-
+			addr := fmt.Sprintf(tc.addr, tc.wantUser, tc.wantRepo)
 			g := commit.Git{
 				Dir: dir,
 			}
@@ -146,9 +157,9 @@ func testGitRepoInfo(t *testing.T) {
 			require.NoError(t, err, string(out))
 
 			user, repo, err := g.RepoInfo(context.Background())
-			require.NoError(t, err)
-			assert.Equal(t, wantUser, user)
-			assert.Equal(t, wantRepo, repo)
+			require.NoError(t, err, addr)
+			assert.Equal(t, tc.wantUser, user)
+			assert.Equal(t, tc.wantRepo, repo)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/genproto v0.0.0-20220211171837-173942840c17 // indirect
+	google.golang.org/genproto v0.0.0-20220218161850-94dd64e39d7c // indirect
 	google.golang.org/grpc v1.44.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -749,8 +749,8 @@ google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20211203200212-54befc351ae9/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211206160659-862468c7d6e0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20220211171837-173942840c17 h1:2X+CNIheCutWRyKRte8szGxrE5ggtV4U+NKAbh/oLhg=
-google.golang.org/genproto v0.0.0-20220211171837-173942840c17/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
+google.golang.org/genproto v0.0.0-20220218161850-94dd64e39d7c h1:TU4rFa5APdKTq0s6B7WTsH6Xmx0Knj86s6Biz56mErE=
+google.golang.org/genproto v0.0.0-20220218161850-94dd64e39d7c/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=


### PR DESCRIPTION
This fixes the issue when the `git@github.com:arsham/arshlib.nvim.git` matches `git@github.com:arsham/arshlib` where it should match `git@github.com:arsham/arshlib.nvim`.

Close #30